### PR TITLE
Fixes #5 7.1 crash regarding [NSNull _isResizable]

### DIFF
--- a/YLGIFImage/YLImageView.m
+++ b/YLGIFImage/YLImageView.m
@@ -84,10 +84,7 @@ const NSTimeInterval kMaxTimeStep = 1; // note: To avoid spiral-o-death
     self.accumulator = 0;
     
     if ([image isKindOfClass:[YLGIFImage class]] && image.images) {
-        if(image.images[0])
-            [super setImage:image.images[0]];
-        else
-            [super setImage:nil];
+        [super setImage:nil];
         self.currentFrame = nil;
         self.animatedImage = (YLGIFImage *)image;
         self.loopCountdown = self.animatedImage.loopCount ?: NSUIntegerMax;


### PR DESCRIPTION
It seems in iOS 7.1 there was a change to [UIImageView setImage:] that
was raising an NSInvalidArgumentException due to an unrecognized
selector (_isResizable) being sent to an instance (NSNull)
